### PR TITLE
feat: BookmarkListPage 개발 (미완성)

### DIFF
--- a/src/pages/BookmarkListPage.jsx
+++ b/src/pages/BookmarkListPage.jsx
@@ -1,3 +1,92 @@
+import { useCallback, useEffect, useState } from "react";
+import TabList from "../components/TabList";
+import ItemList from "../components/ItemList";
+import styled from "styled-components";
+import { useDispatch, useSelector } from "react-redux";
+import { productListActions } from "../store/ProductListSlice";
+
 export default function BookmarkListPage() {
-  return <>{"Bookmark Page"}</>;
+  const filteredItem = useSelector((state) => state.productList.items);
+  const filteredType = useSelector((state) => state.productList.currentType);
+  const viewLimit = useSelector((state) => state.productList.limit);
+  const page = useSelector((state) => state.productList.page);
+  const endPage = useSelector((state) => state.productList.endPage);
+  const inview = useSelector((state) => state.productList.inview);
+  const bookmarkItem = useSelector((state) => state.bookmark);
+  const dispatch = useDispatch();
+
+  const [item, setItem] = useState([]);
+
+  useEffect(() => {
+    dispatch(productListActions.clearItems());
+
+    if (filteredType === "All") {
+      dispatch(productListActions.addItems(bookmarkItem));
+      dispatch(
+        productListActions.setEndPage(
+          Math.ceil(bookmarkItem.length / viewLimit)
+        )
+      );
+    } else {
+      dispatch(
+        productListActions.addItems(
+          bookmarkItem.filter((v) => v.type === filteredType)
+        )
+      );
+      dispatch(
+        productListActions.setEndPage(
+          Math.ceil(filteredItem.length / viewLimit)
+        )
+      );
+    }
+    setItem([]);
+    dispatch(productListActions.resetPage());
+  }, [filteredType, bookmarkItem]);
+  // 의존성 배열에 bookmarkItem을 넣으면 리렌더링이 되므로 오류가 터지는 것 같음
+  // 빼면 오류는 안나지만 북마크 제거한 것이 즉시 반영이 안되고, 새로고침을 해야 적용됨. 하지만 오류는 나지 않음.
+
+  useEffect(() => {
+    if (inview) {
+      dispatch(productListActions.increasePage());
+    }
+  }, [inview]);
+
+  const getItems = useCallback(() => {
+    page < endPage &&
+      setItem((prev) =>
+        prev.concat(
+          filteredItem.slice(page * viewLimit, page * viewLimit + viewLimit)
+        )
+      );
+  }, [page, endPage, filteredItem, viewLimit]);
+
+  useEffect(() => {
+    getItems();
+  }, [getItems]);
+
+  return (
+    <Wrapper>
+      <MainContainer>
+        <TabList />
+        <ItemList data={item} />
+      </MainContainer>
+    </Wrapper>
+  );
 }
+
+const Wrapper = styled.section`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+const MainContainer = styled.section`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding: 0px;
+  gap: 12px;
+
+  width: 66rem;
+`;


### PR DESCRIPTION
! 이전에 리뷰해주신 부분은 북마크 페이지 끝나면 바로 적용해보겠습니다!!

일단 상품 리스트 페이지에서는 무한 스크롤이 정상 동작합니다.

https://github.com/novice-hero/fe-sprint-coz-shopping/assets/77836614/190108ad-4d56-4d39-abfa-fa6d93725f73

궁금한 점
- useState와 redux toolkit을 섞어서 만들었는데 이런 식으로 만드는 게 맞는지, slice들은 이런 식으로 사용하는 게 맞는지 궁금합니다!
- useState와 redux
```jsx
export default function ProductListPage() {
  const filteredItem = useSelector((state) => state.productList.items);
  const filteredType = useSelector((state) => state.productList.currentType);
  const viewLimit = useSelector((state) => state.productList.limit);
  const page = useSelector((state) => state.productList.page);
  const endPage = useSelector((state) => state.productList.endPage);
  const inview = useSelector((state) => state.productList.inview);
  const dispatch = useDispatch();

  const [item, setItem] = useState([]);

  useEffect(() => {
    const fetchAllData = async () => {
      const data = await cozShoppingApi.getAllItem();
      dispatch(productListActions.clearItems());

      if (filteredType === "All") {
        dispatch(productListActions.addItems(data));
        dispatch(
          productListActions.setEndPage(Math.ceil(data.length / viewLimit))
        );
      } else {
        dispatch(
          productListActions.addItems(
            data.filter((v) => v.type === filteredType)
          )
        );
        dispatch(
          productListActions.setEndPage(
            Math.ceil(filteredItem.length / viewLimit)
          )
        );
      }
      setItem([]);
      dispatch(productListActions.resetPage());
    };

    fetchAllData();
  }, [dispatch, filteredItem.length, filteredType, viewLimit]);

  useEffect(() => {
    if (inview) {
      dispatch(productListActions.increasePage());
    }
  }, [inview]);

  const getItems = useCallback(() => {
    page < endPage &&
      setItem((prev) =>
        prev.concat(
          filteredItem.slice(page * viewLimit, page * viewLimit + viewLimit)
        )
      );
  }, [page, endPage, filteredItem, viewLimit]);

  useEffect(() => {
    getItems();
  }, [getItems]);

  return (
    <Wrapper>
      <MainContainer>
        <TabList />
        <ItemList data={item} />
      </MainContainer>
    </Wrapper>
  );
}
```
이 코드에서 `page`를 useState로 사용해서 setPage로 하면 필터를 클릭해서 왔다갔다할 때, 다른 페이지에서 상품 리스트를 들어갔을 때,
0페이지와 1페이지를 먼저 불러와서 렌더링한 후에, 스크롤이 될 때 0페이지부터 다시 불러와서 붙이더라구요.
그런데 page를 slice에 넣고 전역으로 관리하니까 그런 오류가 사라졌습니다.
useState와 redux의 작동 원리가 달라서 이런 현상이 발생하는 것인가요??

---

북마크 페이지의 문제점

문제점 1.

https://github.com/novice-hero/fe-sprint-coz-shopping/assets/77836614/8797f9e6-cd6f-4489-99b1-80631a0cf023

상품 리스트 페이지에서 북마크 페이지로 넘어가면 상품 리스트 페이지의 첫 아이템들이 렌더링 되고, 그 뒤에 북마크 아이템들이 렌더링 되는 점입니다.
탭을 클릭해서 바꾸면 북마크 아이템들만 정상적으로 나옵니다.

문제점 2.

https://github.com/novice-hero/fe-sprint-coz-shopping/assets/77836614/f62692b3-4b4c-40c4-8e04-4c92a8b3209c

북마크를 제거했을 때 무한 스크롤이 되어 있던 곳이라면 초기화 되고 다시 스크롤 해야 하는 점
-> state 문제일까요? 아니면 스크롤의 위치를 따로 저장해서 제거할 때마다 불러와야할까요?

