### PR TITLE
fix: 처음 로드 시 2페이지까지 로드하는 현상 해결

### DIFF
--- a/src/pages/ProductListPage.jsx
+++ b/src/pages/ProductListPage.jsx
@@ -15,9 +15,9 @@ export default function ProductListPage() {
   const dispatch = useDispatch();
 
   const [page, setPage] = useState(1);
-  const [inviewHandled, setInviewHandled] = useState(false);
 
   const filteredItem = useMemo(() => {
+    setPage(1);
     if (filteredType === "All") {
       return items;
     } else return items.filter((item) => item.type === filteredType);
@@ -33,13 +33,11 @@ export default function ProductListPage() {
       dispatch(productListActions.updateItems(data));
     };
     fetchAllData();
-    setInviewHandled(true);
   }, [dispatch, filteredType]);
 
   useEffect(() => {
-    if (inview && !inviewHandled) setPage((prev) => prev + 1);
-    setInviewHandled(false);
-  }, [inview, inviewHandled]);
+    if (inview) setPage((prev) => prev + 1);
+  }, [inview]);
 
   return (
     <Wrapper>

--- a/src/pages/ProductListPage.jsx
+++ b/src/pages/ProductListPage.jsx
@@ -15,6 +15,7 @@ export default function ProductListPage() {
   const dispatch = useDispatch();
 
   const [page, setPage] = useState(1);
+  const [inviewHandled, setInviewHandled] = useState(false);
 
   const filteredItem = useMemo(() => {
     if (filteredType === "All") {
@@ -32,11 +33,13 @@ export default function ProductListPage() {
       dispatch(productListActions.updateItems(data));
     };
     fetchAllData();
+    setInviewHandled(true);
   }, [dispatch, filteredType]);
 
   useEffect(() => {
-    if (inview) setPage((prev) => prev + 1);
-  }, [inview]);
+    if (inview && !inviewHandled) setPage((prev) => prev + 1);
+    setInviewHandled(false);
+  }, [inview, inviewHandled]);
 
   return (
     <Wrapper>


### PR DESCRIPTION
- 처음에 했던 방식 다시 에러가 발생하여 수정했습니다.

---

문제점: 최초 로드 시 2페이지까지 불러오는 에러

```jsx
const filteredItem = useMemo(() => {
    setPage(1);
    if (filteredType === "All") {
      return items;
    } else return items.filter((item) => item.type === filteredType);
  }, [filteredType, items]);
```

상품 정보가 필터되어서 리턴되기 전에 페이지를 1로 변경해주는 것으로 해결하였습니다.

이 접근이 맞을까요??